### PR TITLE
refactor!: handle timer config defaults in daemon

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -153,68 +153,6 @@ pub struct TimerArgs {
     pub volume: Option<f32>,
 }
 
-impl TimerArgs {
-    /// Get work duration with fallback
-    pub fn get_work(&self, default: f32) -> f32 {
-        self.work.unwrap_or(default)
-    }
-
-    /// Get break duration with fallback
-    pub fn get_break_time(&self, default: f32) -> f32 {
-        self.break_time.unwrap_or(default)
-    }
-
-    /// Get long break duration with fallback
-    pub fn get_long_break(&self, default: f32) -> f32 {
-        self.long_break.unwrap_or(default)
-    }
-
-    /// Get sessions with fallback
-    pub fn get_sessions(&self, default: u32) -> u32 {
-        self.sessions.unwrap_or(default)
-    }
-
-    /// Get auto_advance with fallback - returns string to avoid circular dependency
-    pub fn get_auto_advance_str(&self, default_str: &str) -> String {
-        self.auto_advance
-            .clone()
-            .unwrap_or_else(|| default_str.to_string())
-    }
-
-    /// Get sound mode with fallback, considering deprecated fields
-    pub fn get_sound_mode(&self, default_str: &str) -> String {
-        // Check for new sound_mode first
-        if let Some(ref mode) = self.sound_mode {
-            return mode.clone();
-        }
-
-        // Handle deprecated flags for backwards compatibility
-        if self.beep {
-            return "system-beep".to_string();
-        }
-        if self.sound {
-            return "embedded".to_string();
-        }
-
-        default_str.to_string()
-    }
-
-    /// Get volume with fallback
-    pub fn get_volume(&self, default: f32) -> f32 {
-        match self.volume {
-            Some(v) if (0.0..=1.0).contains(&v) => v,
-            Some(v) => {
-                eprintln!(
-                    "Warning: Volume {} out of range (0.0-1.0), using {}",
-                    v, default
-                );
-                default
-            }
-            None => default,
-        }
-    }
-}
-
 #[derive(Subcommand)]
 pub enum Commands {
     /// Manage the background daemon

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,6 @@ async fn fetch_and_format_status(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
-    let config = Config::load();
 
     match cli.command {
         Commands::Daemon { action } => match action {
@@ -82,46 +81,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Commands::Start { timer } => {
-            let work = timer.get_work(config.timer.work);
-            let break_time = timer.get_break_time(config.timer.break_time);
-            let long_break = timer.get_long_break(config.timer.long_break);
-            let sessions = timer.get_sessions(config.timer.sessions);
+            // Only send values that were explicitly provided
+            // Daemon will use config defaults for missing values
+            let mut args = serde_json::json!({});
 
-            // Get auto_advance mode as string
-            let default_mode_str = match config.timer.auto_advance {
-                config::AutoAdvanceMode::None => "none",
-                config::AutoAdvanceMode::All => "all",
-                config::AutoAdvanceMode::ToBreak => "to-break",
-                config::AutoAdvanceMode::ToWork => "to-work",
-            };
-            let auto_advance_str = timer.get_auto_advance_str(default_mode_str);
-
-            // Get sound mode as string
-            let default_sound_mode = match config.sound.effective_mode() {
-                config::SoundMode::Embedded => "embedded",
-                config::SoundMode::SystemBeep => "system-beep",
-                config::SoundMode::None => "none",
-            };
-            let sound_mode = timer.get_sound_mode(default_sound_mode);
-            let volume = timer.get_volume(config.sound.volume);
-
-            let args = serde_json::json!({
-                "work": work,
-                "break": break_time,
-                "long_break": long_break,
-                "sessions": sessions,
-                "auto_advance": auto_advance_str,
-                "sound_mode": sound_mode,
-                "volume": volume
-            });
+            if let Some(work) = timer.work {
+                args["work"] = serde_json::json!(work);
+            }
+            if let Some(break_time) = timer.break_time {
+                args["break"] = serde_json::json!(break_time);
+            }
+            if let Some(long_break) = timer.long_break {
+                args["long_break"] = serde_json::json!(long_break);
+            }
+            if let Some(sessions) = timer.sessions {
+                args["sessions"] = serde_json::json!(sessions);
+            }
+            if let Some(auto_advance) = &timer.auto_advance {
+                args["auto_advance"] = serde_json::json!(auto_advance);
+            }
+            if let Some(sound_mode) = &timer.sound_mode {
+                args["sound_mode"] = serde_json::json!(sound_mode);
+            }
+            if let Some(volume) = timer.volume {
+                args["volume"] = serde_json::json!(volume);
+            }
 
             match send_command("start", args).await {
                 Ok(response) => {
                     if response.success {
-                        println!(
-                            "Pomodoro started: {}min work, {}min break, {}min long break every {} sessions",
-                            work, break_time, long_break, sessions
-                        );
+                        println!("{}", response.message);
                     } else {
                         eprintln!("Error: {}", response.message);
                     }
@@ -142,7 +131,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         },
 
         Commands::Status { output, format } => {
-            let text_template = format.unwrap_or(config.display.text_format);
+            // Load config only for display format default
+            let text_template = format.unwrap_or_else(|| Config::load().display.text_format);
 
             match fetch_and_format_status(&output, &text_template).await {
                 Ok(output) => println!("{}", output),
@@ -155,7 +145,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             format,
             interval,
         } => {
-            let text_template = format.unwrap_or(config.display.text_format);
+            // Load config only for display format default
+            let text_template = format.unwrap_or_else(|| Config::load().display.text_format);
             let interval_duration = std::time::Duration::from_secs_f64(interval);
 
             loop {

--- a/src/server.rs
+++ b/src/server.rs
@@ -190,22 +190,22 @@ async fn handle_client(
                 .args
                 .get("work")
                 .and_then(|v| v.as_f64())
-                .unwrap_or(25.0) as f32;
+                .unwrap_or(config.timer.work as f64) as f32;
             let break_time = message
                 .args
                 .get("break")
                 .and_then(|v| v.as_f64())
-                .unwrap_or(5.0) as f32;
+                .unwrap_or(config.timer.break_time as f64) as f32;
             let long_break = message
                 .args
                 .get("long_break")
                 .and_then(|v| v.as_f64())
-                .unwrap_or(15.0) as f32;
+                .unwrap_or(config.timer.long_break as f64) as f32;
             let sessions = message
                 .args
                 .get("sessions")
                 .and_then(|v| v.as_u64())
-                .unwrap_or(4) as u32;
+                .unwrap_or(config.timer.sessions as u64) as u32;
             let auto_advance = message
                 .args
                 .get("auto_advance")
@@ -223,7 +223,7 @@ async fn handle_client(
                         })
                     }
                 })
-                .unwrap_or(crate::config::AutoAdvanceMode::None);
+                .unwrap_or_else(|| config.timer.auto_advance.clone());
 
             // Parse sound_mode (ignore for now, not stored in state)
             let _sound_mode = message
@@ -472,15 +472,26 @@ pub async fn run_daemon() -> Result<(), Box<dyn std::error::Error>> {
 
     let listener = UnixListener::bind(&socket_path)?;
 
-    // Try to load existing state, fallback to default if not found
-    let mut state = load_state().unwrap_or_else(|| {
-        println!("No existing state found, starting with default state");
-        println!("  Using: work=25min, break=5min, long_break=15min, sessions=4");
-        TimerState::new(25.0, 5.0, 15.0, 4)
-    });
-
-    // Load configuration
+    // Load configuration first
     let config = crate::config::Config::load_with_logging(true);
+
+    // Try to load existing state, fallback to config defaults if not found
+    let mut state = load_state().unwrap_or_else(|| {
+        println!("No existing state found, starting with config defaults");
+        println!(
+            "  Using: work={}min, break={}min, long_break={}min, sessions={}",
+            config.timer.work,
+            config.timer.break_time,
+            config.timer.long_break,
+            config.timer.sessions
+        );
+        TimerState::new(
+            config.timer.work,
+            config.timer.break_time,
+            config.timer.long_break,
+            config.timer.sessions,
+        )
+    });
 
     println!("Tomat daemon listening on {:?}", socket_path);
 

--- a/tests/integration/timer.rs
+++ b/tests/integration/timer.rs
@@ -300,3 +300,41 @@ fn test_manual_skip_respects_auto_advance_setting() -> Result<(), Box<dyn std::e
 
     Ok(())
 }
+
+#[test]
+fn test_daemon_uses_config_for_defaults() -> Result<(), Box<dyn std::error::Error>> {
+    use std::io::Write;
+
+    // Create a config file with custom durations
+    let temp_dir = tempfile::tempdir()?;
+    let config_path = temp_dir.path().join("config.toml");
+    let mut config_file = std::fs::File::create(&config_path)?;
+    writeln!(
+        config_file,
+        r#"
+[timer]
+work = 42.0
+break = 8.0
+long_break = 20.0
+sessions = 3
+"#
+    )?;
+
+    // Start daemon with this config
+    let daemon = TestDaemon::start_with_config(Some(&config_path))?;
+
+    // Start timer without any arguments - should use config values
+    daemon.send_command(&["start"])?;
+
+    let status = daemon.get_status()?;
+    let text = status.get("text").and_then(|v| v.as_str()).unwrap();
+
+    // Should show 42:00 from config, not 25:00 from hardcoded defaults
+    assert!(
+        text.contains("42:00"),
+        "Timer should use config work duration (42 min) when no args provided. Got: {}",
+        text
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
The daemon now "owns" the defaults for the timer configuration and loads them once at startup, just like other similar services. Previously, the CLI client would send all commands to the daemon every time after loading the config.

The CLI agent now only pushes overrides for the config and defaults, and does not load the config defaults (for the timer).