### PR TITLE
chore(release): v2.13.0

### DIFF
--- a/.versionary-manifest.json
+++ b/.versionary-manifest.json
@@ -1,18 +1,18 @@
 {
   "manifest-version": 1,
-  "baseline-sha": "c77da94ab502a64d47433e693175c9a00c5db8ec",
+  "baseline-sha": "ddd011ad6f5084de77cbf538753960296396291a",
   "release-targets": [
     {
       "path": ".",
-      "version": "2.12.0",
-      "tag": "v2.12.0"
+      "version": "2.13.0",
+      "tag": "v2.13.0"
     }
   ],
   "pending-release-targets": [
     {
       "path": ".",
-      "version": "2.12.0",
-      "tag": "v2.12.0"
+      "version": "2.13.0",
+      "tag": "v2.13.0"
     }
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.13.0](https://github.com/jolars/tomat/compare/v2.12.0...v2.13.0) (2026-08-27)
+
+### Features
+- add one-line installer script ([`48765b7`](https://github.com/jolars/tomat/commit/48765b7801058815a08a9d0ac54c2cf04f041b66))
+- add macOS support ([`4771ade`](https://github.com/jolars/tomat/commit/4771adeaf53c4824c0dfbf8243276898969b75ee))
+
 ## [2.12.0](https://github.com/jolars/tomat/compare/v2.11.0...v2.12.0) (2026-08-27)
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2113,7 +2113,7 @@ dependencies = [
 
 [[package]]
 name = "tomat"
-version = "2.12.0"
+version = "2.13.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tomat"
-version = "2.12.0"
+version = "2.13.0"
 edition = "2024"
 description = "A cross-platform Pomodoro timer with daemon support"
 license = "MIT"

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
         tomat = pkgs.rustPlatform.buildRustPackage {
           pname = "tomat";
-          version = "2.12.0";
+          version = "2.13.0";
 
           src = pkgs.lib.cleanSourceWith {
             src = ./.;


### PR DESCRIPTION
## [2.13.0](https://github.com/jolars/tomat/compare/v2.12.0...v2.13.0) (2026-08-27)

### Features
- add one-line installer script ([`48765b7`](https://github.com/jolars/tomat/commit/48765b7801058815a08a9d0ac54c2cf04f041b66))
- add macOS support ([`4771ade`](https://github.com/jolars/tomat/commit/4771adeaf53c4824c0dfbf8243276898969b75ee))

---

This PR was generated by [Versionary](https://github.com/jolars/versionary).